### PR TITLE
Add .gitignore, remove unused local variables and use dots and spaces instead of ones and zeros in bitmap thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.ppu
+*.o
+pesdump
+

--- a/midlevelio.pas
+++ b/midlevelio.pas
@@ -973,7 +973,7 @@ const
 var
   patchLoc: longint;
   bitmap: TScalarArray;
-  i, r: integer;
+  i: integer;
 
 begin
 {$ifdef HAS_CURRENTROUTINE }

--- a/midlevelio.pas
+++ b/midlevelio.pas
@@ -340,9 +340,9 @@ var
     result := '';
     while bits > 0 do begin
       if Odd(b) then
-        result += '1'
+        result += Dot  (* '1' *)
       else
-        result += '0';
+        result += ' ';  (* '0' *)
       b := b >> 1;
       bits -= 1
     end

--- a/pesdump.lpr
+++ b/pesdump.lpr
@@ -666,7 +666,7 @@ const
 
 var
   backtrack: int64;
-  i, v: integer;
+  v: integer;
 
 begin
 {$ifdef HAS_CURRENTROUTINE }
@@ -728,7 +728,7 @@ const
 
 var
   backtrack: int64;
-  i, t, v, x, y: integer;
+  i, t, v: integer;
 {$ifdef FPC }
   stitch: TScalarArray;
 {$endif FPC }
@@ -1297,7 +1297,6 @@ function pes_file(): boolean;
 
 var
   backtrack: int64;
-  currentRoutine: ansistring;
 
 begin
 {$ifdef HAS_CURRENTROUTINE }


### PR DESCRIPTION
Hi @MarkMLl ,

thanks for your help in #1 !

The `pesdump` tool now both compiles and works!

I directly tried to contribute something back and so I created this pull request.

I made the following changes:

1. I added a `.gitignore` file that lists `*.ppu` and `*.o` files and the name of the compiled executable `pesdump`- this prevents committing those artifacts (I almost did commit them accidentially)
2. I've replaced the `1` and `0` in the bitmap thumbnail output by the middle dot you've already been using `·` and a simple space character ` `. In my opinion this makes it easier for the eye to grasp the pattern. (Details below.)
3. I've removed local variables that seemed to be unused, as the fpc mentioned them in ~~warnings~~ notes during compilation. (Details below.)

Thanks for your tool and the time you've put into it! It really seems helpful!

I am totally OK if you don't want to merge all or any of those changes as they might not add big value to the project or even break things (thinking of post-processing those thumbnail previews).

---

Details about the thumbnails:

I've tried to get some free PES sample files to play around. Interestingly, Brother themselves provide some here: https://sewingcraft.brother.eu/en/inspiration-and-events/projects-and-free-patterns

Even more interesting: the newer files from 2024 seem to use newer file versions (seen `0080` in the "Paw Print" and even `0100` in the "Easter bunny"). So this file format still needs to be extended with new features - I am surprised! Going further down the list, the "Magic mushrooms" (file name `Embroidery202401pes.pes`) is the first one that uses an older version (`0001`) and that worked with your tool.

From the (modified) preview in "dot-space" style:

```
Thumbnail colour: 0
                          |P1
                          |# Thumbnail 0, colour 26 (Light Brown)
                          |48 38
055A2  00 00 00·00 00 00  |                                                
055A8  F0 FF FF·FF FF 0F  |    ········································    
055AE  08 00 00·00 00 10  |   ·                                        ·   
055B4  04 00 00·00 00 20  |  ·                                          ·  
055BA  02 00 00·00 00 40  | ·                                            · 
055C0  02 00 00·1C 00 40  | ·                        ···                 · 
055C6  02 00 00·7E 00 40  | ·                       ······               · 
055CC  02 00 60·7F 00 40  | ·                   ·· ·······               · 
055D2  02 00 F8·FF 00 40  | ·                 ·············              · 
055D8  02 00 FC·FF 01 40  | ·                ···············             · 
055DE  02 00 FE·FF 01 40  | ·               ················             · 
055E4  02 00 FF·FF 03 40  | ·              ··················            · 
055EA  02 80 FF·FF 03 40  | ·             ···················            · 
055F0  02 80 FF·FF 03 40  | ·             ···················            · 
055F6  02 80 FF·FF 00 40  | ·             ·················              · 
055FC  02 80 FF·3F 00 40  | ·             ···············                · 
05602  02 80 FF·3F 00 40  | ·             ···············                · 
05608  02 00 FF·3F 00 40  | ·              ··············                · 
0560E  02 00 F0·3C 01 40  | ·                  ····  ····  ·             · 
05614  02 00 E0·3C 01 40  | ·                   ···  ····  ·             · 
0561A  02 00 E0·3C 01 40  | ·                   ···  ····  ·             · 
05620  02 00 E0·BE 01 40  | ·                   ··· ····· ··             · 
05626  02 00 F0·FF 03 40  | ·                  ··············            · 
0562C  02 00 F0·FF 03 40  | ·                  ··············            · 
05632  02 00 F0·FF 03 40  | ·                  ··············            · 
05638  02 00 F8·FF 03 40  | ·                 ···············            · 
0563E  02 00 FC·FF 03 40  | ·                ················            · 
05644  02 00 FE·FF 03 40  | ·               ·················            · 
0564A  02 00 FE·FE 03 40  | ·               ······· ·········            · 
05650  02 00 FF·FE 03 40  | ·              ········ ·········            · 
05656  02 00 FF·FF 01 40  | ·              ·················             · 
0565C  02 00 FF·FF 01 40  | ·              ·················             · 
05662  02 80 F7·9F 00 40  | ·             ···· ·········  ·              · 
05668  02 00 83·1E 00 40  | ·              ··     · ····                 · 
0566E  04 00 00·00 00 20  |  ·                                          ·  
05674  08 00 00·00 00 10  |   ·                                        ·   
0567A  F0 FF FF·FF FF 0F  |    ········································    
05680  00 00 00·00 00 00  |
...
Thumbnail colour: 7
                          |P1
                          |# Thumbnail 7
                          |48 38
05BDE  00 00 00·00 00 00  |                                                
05BE4  F0 FF FF·FF FF 0F  |    ········································    
05BEA  08 00 00·00 00 10  |   ·                                        ·   
05BF0  04 00 00·00 00 20  |  ·                                          ·  
05BF6  02 00 00·00 00 40  | ·                                            · 
05BFC  02 00 00·1C 00 40  | ·                        ···                 · 
05C02  02 00 00·36 00 40  | ·                       ·· ··                · 
05C08  02 00 40·57 00 40  | ·                    · ··· · ·               · 
05C0E  02 00 F0·E5 00 40  | ·                  ····· ·  ···              · 
05C14  02 00 6C·E7 01 40  | ·                ·· ·· ···  ····             · 
05C1A  02 00 34·D6 01 40  | ·                · ··   ·· · ···             · 
05C20  02 00 E3·96 03 40  | ·              ··   ··· ·· ·  ···            · 
05C26  02 80 21·7F 03 40  | ·             ··    ·  ······· ··            · 
05C2C  02 80 A7·D1 03 40  | ·             ····  · ··   · ····            · 
05C32  02 80 E7·FE 00 40  | ·             ····  ··· ·······              · 
05C38  02 80 0F·1F 00 40  | ·             ·····    ·····                 · 
05C3E  02 00 0F·2F 00 40  | ·              ····    ···· ·                · 
05C44  02 00 FE·27 00 40  | ·               ··········  ·                · 
05C4A  02 00 A0·24 01 40  | ·                   · ·  ·  ·  ·             · 
05C50  02 00 A0·24 01 40  | ·                   · ·  ·  ·  ·             · 
05C56  02 00 A0·3C 01 40  | ·                   · ·  ····  ·             · 
05C5C  02 00 A0·BE 01 40  | ·                   · · ····· ··             · 
05C62  02 00 A0·EB 01 40  | ·                   · ··· · ····             · 
05C68  02 00 90·EF 02 40  | ·                  ·  ····· ··· ·            · 
05C6E  02 00 90·90 00 40  | ·                  ·  ·    ·  ·              · 
05C74  02 00 98·FF 02 40  | ·                 ··  ········· ·            · 
05C7A  02 00 9C·F9 02 40  | ·                ···  ··  ····· ·            · 
05C80  02 00 BE·7F 03 40  | ·               ····· ········ ··            · 
05C86  02 00 BE·F6 03 40  | ·               ····· · ·· ······            · 
05C8C  02 00 FE·E6 01 40  | ·               ······· ··  ····             · 
05C92  02 00 FF·AE 00 40  | ·              ········ ··· · ·              · 
05C98  02 00 FB·3E 00 40  | ·              ·· ····· ·····                · 
05C9E  02 00 A0·1C 00 40  | ·                   · ·  ···                 · 
05CA4  02 00 00·00 00 40  | ·                                            · 
05CAA  04 00 00·00 00 20  |  ·                                          ·  
05CB0  08 00 00·00 00 10  |   ·                                        ·   
05CB6  F0 FF FF·FF FF 0F  |    ········································    
05CBC  00 00 00·00 00 00  |
```

The same file in "ones-zeros" style:

```
Thumbnail colour: 0
                          |P1
                          |# Thumbnail 0, colour 26 (Light Brown)
                          |48 38
055A2  00 00 00·00 00 00  |000000000000000000000000000000000000000000000000
055A8  F0 FF FF·FF FF 0F  |000011111111111111111111111111111111111111110000
055AE  08 00 00·00 00 10  |000100000000000000000000000000000000000000001000
055B4  04 00 00·00 00 20  |001000000000000000000000000000000000000000000100
055BA  02 00 00·00 00 40  |010000000000000000000000000000000000000000000010
055C0  02 00 00·1C 00 40  |010000000000000000000000001110000000000000000010
055C6  02 00 00·7E 00 40  |010000000000000000000000011111100000000000000010
055CC  02 00 60·7F 00 40  |010000000000000000000110111111100000000000000010
055D2  02 00 F8·FF 00 40  |010000000000000000011111111111110000000000000010
055D8  02 00 FC·FF 01 40  |010000000000000000111111111111111000000000000010
055DE  02 00 FE·FF 01 40  |010000000000000001111111111111111000000000000010
055E4  02 00 FF·FF 03 40  |010000000000000011111111111111111100000000000010
055EA  02 80 FF·FF 03 40  |010000000000000111111111111111111100000000000010
055F0  02 80 FF·FF 03 40  |010000000000000111111111111111111100000000000010
055F6  02 80 FF·FF 00 40  |010000000000000111111111111111110000000000000010
055FC  02 80 FF·3F 00 40  |010000000000000111111111111111000000000000000010
05602  02 80 FF·3F 00 40  |010000000000000111111111111111000000000000000010
05608  02 00 FF·3F 00 40  |010000000000000011111111111111000000000000000010
0560E  02 00 F0·3C 01 40  |010000000000000000001111001111001000000000000010
05614  02 00 E0·3C 01 40  |010000000000000000000111001111001000000000000010
0561A  02 00 E0·3C 01 40  |010000000000000000000111001111001000000000000010
05620  02 00 E0·BE 01 40  |010000000000000000000111011111011000000000000010
05626  02 00 F0·FF 03 40  |010000000000000000001111111111111100000000000010
0562C  02 00 F0·FF 03 40  |010000000000000000001111111111111100000000000010
05632  02 00 F0·FF 03 40  |010000000000000000001111111111111100000000000010
05638  02 00 F8·FF 03 40  |010000000000000000011111111111111100000000000010
0563E  02 00 FC·FF 03 40  |010000000000000000111111111111111100000000000010
05644  02 00 FE·FF 03 40  |010000000000000001111111111111111100000000000010
0564A  02 00 FE·FE 03 40  |010000000000000001111111011111111100000000000010
05650  02 00 FF·FE 03 40  |010000000000000011111111011111111100000000000010
05656  02 00 FF·FF 01 40  |010000000000000011111111111111111000000000000010
0565C  02 00 FF·FF 01 40  |010000000000000011111111111111111000000000000010
05662  02 80 F7·9F 00 40  |010000000000000111101111111110010000000000000010
05668  02 00 83·1E 00 40  |010000000000000011000001011110000000000000000010
0566E  04 00 00·00 00 20  |001000000000000000000000000000000000000000000100
05674  08 00 00·00 00 10  |000100000000000000000000000000000000000000001000
0567A  F0 FF FF·FF FF 0F  |000011111111111111111111111111111111111111110000
05680  00 00 00·00 00 00  |000000000000000000000000000000000000000000000000
...
Thumbnail colour: 7
                          |P1
                          |# Thumbnail 7
                          |48 38
05BDE  00 00 00·00 00 00  |000000000000000000000000000000000000000000000000
05BE4  F0 FF FF·FF FF 0F  |000011111111111111111111111111111111111111110000
05BEA  08 00 00·00 00 10  |000100000000000000000000000000000000000000001000
05BF0  04 00 00·00 00 20  |001000000000000000000000000000000000000000000100
05BF6  02 00 00·00 00 40  |010000000000000000000000000000000000000000000010
05BFC  02 00 00·1C 00 40  |010000000000000000000000001110000000000000000010
05C02  02 00 00·36 00 40  |010000000000000000000000011011000000000000000010
05C08  02 00 40·57 00 40  |010000000000000000000010111010100000000000000010
05C0E  02 00 F0·E5 00 40  |010000000000000000001111101001110000000000000010
05C14  02 00 6C·E7 01 40  |010000000000000000110110111001111000000000000010
05C1A  02 00 34·D6 01 40  |010000000000000000101100011010111000000000000010
05C20  02 00 E3·96 03 40  |010000000000000011000111011010011100000000000010
05C26  02 80 21·7F 03 40  |010000000000000110000100111111101100000000000010
05C2C  02 80 A7·D1 03 40  |010000000000000111100101100010111100000000000010
05C32  02 80 E7·FE 00 40  |010000000000000111100111011111110000000000000010
05C38  02 80 0F·1F 00 40  |010000000000000111110000111110000000000000000010
05C3E  02 00 0F·2F 00 40  |010000000000000011110000111101000000000000000010
05C44  02 00 FE·27 00 40  |010000000000000001111111111001000000000000000010
05C4A  02 00 A0·24 01 40  |010000000000000000000101001001001000000000000010
05C50  02 00 A0·24 01 40  |010000000000000000000101001001001000000000000010
05C56  02 00 A0·3C 01 40  |010000000000000000000101001111001000000000000010
05C5C  02 00 A0·BE 01 40  |010000000000000000000101011111011000000000000010
05C62  02 00 A0·EB 01 40  |010000000000000000000101110101111000000000000010
05C68  02 00 90·EF 02 40  |010000000000000000001001111101110100000000000010
05C6E  02 00 90·90 00 40  |010000000000000000001001000010010000000000000010
05C74  02 00 98·FF 02 40  |010000000000000000011001111111110100000000000010
05C7A  02 00 9C·F9 02 40  |010000000000000000111001100111110100000000000010
05C80  02 00 BE·7F 03 40  |010000000000000001111101111111101100000000000010
05C86  02 00 BE·F6 03 40  |010000000000000001111101011011111100000000000010
05C8C  02 00 FE·E6 01 40  |010000000000000001111111011001111000000000000010
05C92  02 00 FF·AE 00 40  |010000000000000011111111011101010000000000000010
05C98  02 00 FB·3E 00 40  |010000000000000011011111011111000000000000000010
05C9E  02 00 A0·1C 00 40  |010000000000000000000101001110000000000000000010
05CA4  02 00 00·00 00 40  |010000000000000000000000000000000000000000000010
05CAA  04 00 00·00 00 20  |001000000000000000000000000000000000000000000100
05CB0  08 00 00·00 00 10  |000100000000000000000000000000000000000000001000
05CB6  F0 FF FF·FF FF 0F  |000011111111111111111111111111111111111111110000
05CBC  00 00 00·00 00 00  |000000000000000000000000000000000000000000000000
```

---

Warnings+notes from `fpc` after my changes:

```
$ fpc pesdump.lpr 
Free Pascal Compiler version 3.2.2+dfsg-9ubuntu1 [2022/04/11] for x86_64
Copyright (c) 1993-2021 by Florian Klaempfl and others
Target OS: Linux for x86-64
Compiling pesdump.lpr
Compiling patchandio.pas
patchandio.pas(605,17) Warning: Local variable "patch" of a managed type does not seem to be initialized
Compiling midlevelio.pas
midlevelio.pas(354,5) Warning: Local variable "chars" of a managed type does not seem to be initialized
midlevelio.pas(804,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(849,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(894,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(939,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(976,6) Note: Local variable "r" not used
pesdump.lpr(227,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(521,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(549,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(590,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(669,3) Note: Local variable "i" not used
pesdump.lpr(730,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(731,12) Note: Local variable "x" not used
pesdump.lpr(731,15) Note: Local variable "y" not used
pesdump.lpr(803,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(1300,3) Note: Local variable "currentRoutine" not used
pesdump.lpr(210,3) Note: Local variable "waitingForPec" is assigned but never used
Linking pesdump
3947 lines compiled, 0.3 sec
6 warning(s) issued
12 note(s) issued
```


Warnings+notes from `fpc` after my changes:

```
$ fpc pesdump.lpr
Free Pascal Compiler version 3.2.2+dfsg-9ubuntu1 [2022/04/11] for x86_64
Copyright (c) 1993-2021 by Florian Klaempfl and others
Target OS: Linux for x86-64
Compiling pesdump.lpr
Compiling patchandio.pas
patchandio.pas(605,17) Warning: Local variable "patch" of a managed type does not seem to be initialized
Compiling midlevelio.pas
midlevelio.pas(354,5) Warning: Local variable "chars" of a managed type does not seem to be initialized
midlevelio.pas(804,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(849,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(894,19) Warning: function result variable of a managed type does not seem to be initialized
midlevelio.pas(939,19) Warning: function result variable of a managed type does not seem to be initialized
pesdump.lpr(227,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(521,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(549,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(590,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(730,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(803,3) Note: Local variable "backtrack" is assigned but never used
pesdump.lpr(210,3) Note: Local variable "waitingForPec" is assigned but never used
Linking pesdump
3946 lines compiled, 0.3 sec
6 warning(s) issued
7 note(s) issued
```

(I didn't really dare to touch `backtrack` as this seems to be used for debugging...)
